### PR TITLE
[RELEASE] v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [3.0.0] - 2026-06-07
+
 > [!IMPORTANT]
 >
 > **This version needs Alliance Auth v5!**
@@ -473,6 +475,7 @@ Run migrations after updating as usual.
 [2.5.1]: https://github.com/ppfeufer/aa-rss-to-discord/compare/v2.5.0...v2.5.1 "v2.5.1"
 [2.5.2]: https://github.com/ppfeufer/aa-rss-to-discord/compare/v2.5.1...v2.5.2 "v2.5.2"
 [2.6.0]: https://github.com/ppfeufer/aa-rss-to-discord/compare/v2.5.2...v2.6.0 "v2.6.0"
-[in development]: https://github.com/ppfeufer/aa-rss-to-discord/compare/v2.6.0...HEAD "In Development"
+[3.0.0]: https://github.com/ppfeufer/aa-rss-to-discord/compare/v2.6.0...v3.0.0 "v3.0.0"
+[in development]: https://github.com/ppfeufer/aa-rss-to-discord/compare/v3.0.0...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth
 installation Then install the latest release directly from PyPi.
 
 ```shell
-pip install aa-rss-to-discord==2.6.0
+pip install aa-rss-to-discord==3.0.0
 ```
 
 ### Step 2: Configure Alliance Auth<a name="step-2-configure-alliance-auth"></a>
@@ -116,7 +116,7 @@ To update your existing installation of Alliance Auth RSS to Discord, first enab
 virtual environment (venv) of your Alliance Auth installation.
 
 ```bash
-pip install aa-rss-to-discord==2.6.0
+pip install aa-rss-to-discord==3.0.0
 
 python manage.py migrate
 ```

--- a/aa_rss_to_discord/__init__.py
+++ b/aa_rss_to_discord/__init__.py
@@ -5,6 +5,6 @@ App init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.6.0"
+__version__ = "3.0.0"
 __title__ = "RSS to Discord"
 __title_translated__ = _("RSS to Discord")


### PR DESCRIPTION
## [3.0.0] - 2026-06-07

> [!IMPORTANT]
> 
> **This version needs Alliance Auth v5!**
> 
> Please make sure to update your Alliance Auth instance **before** you install this
> version, otherwise an update to Alliance Auth will be pulled in unsupervised.

### Removed

- Support for Alliance Auth v4